### PR TITLE
Some implementations are wrong.

### DIFF
--- a/Units/DX12.D2D1.pas
+++ b/Units/DX12.D2D1.pas
@@ -2059,8 +2059,8 @@ type
     ID2D1Bitmap = interface(ID2D1Image)
         ['{a2296057-ea42-4099-983b-539fb6505426}']
         function GetSize(): TD2D1_SIZE_F; stdcall;
-        function GetPixelSize(): TD2D1_SIZE_U; stdcall;
         procedure GetPixelSize(out pixelSize: TD2D1_SIZE_U); stdcall;
+        function GetPixelFormat(): TD2D1_PIXEL_FORMAT; stdcall;
         procedure GetDpi(out dpiX: single; out dpiY: single); stdcall;
         //        function CopyFromBitmap( destPoint: PD2D1_POINT_2U; bitmap: ID2D1Bitmap;  srcRect: PD2D1_RECT_U): HResult; stdcall;  // <- funkt
         function CopyFromBitmap(const destPoint: PD2D1_POINT_2U; bitmap: ID2D1Bitmap; const srcRect: PD2D1_RECT_U): HResult;

--- a/Units/DX12.D2D1.pas
+++ b/Units/DX12.D2D1.pas
@@ -2058,9 +2058,9 @@ type
 
     ID2D1Bitmap = interface(ID2D1Image)
         ['{a2296057-ea42-4099-983b-539fb6505426}']
-        function GetSize(): TD2D1_SIZE_F; stdcall;
-        procedure GetPixelSize(out pixelSize: TD2D1_SIZE_U); stdcall;
-        function GetPixelFormat(): TD2D1_PIXEL_FORMAT; stdcall;
+        procedure GetSize(out size: TD2D1_SIZE_F); stdcall;                    
+        procedure GetPixelSize(out pixelSize: TD2D1_SIZE_U); stdcall;          
+        procedure GetPixelFormat(out PixelFormat: TD2D1_PIXEL_FORMAT); stdcall;
         procedure GetDpi(out dpiX: single; out dpiY: single); stdcall;
         //        function CopyFromBitmap( destPoint: PD2D1_POINT_2U; bitmap: ID2D1Bitmap;  srcRect: PD2D1_RECT_U): HResult; stdcall;  // <- funkt
         function CopyFromBitmap(const destPoint: PD2D1_POINT_2U; bitmap: ID2D1Bitmap; const srcRect: PD2D1_RECT_U): HResult;
@@ -2975,7 +2975,7 @@ type
         function CreateColorContextFromWicColorContext(wicColorContext: IWICColorContext; out colorContext: ID2D1ColorContext): HResult; stdcall;
         function CreateBitmapFromDxgiSurface(surface: IDXGISurface; const bitmapProperties: TD2D1_BITMAP_PROPERTIES1;
             out bitmap: ID2D1Bitmap1): HResult; stdcall;
-        function CreateEffect(effectId: TGUID; out effect: ID2D1Effect): HResult; stdcall;
+        function CreateEffect(effectId: PGUID; out effect: ID2D1Effect): HResult; stdcall;
         function CreateGradientStopCollection(straightAlphaGradientStops: PD2D1_GRADIENT_STOP; straightAlphaGradientStopsCount: UINT32;
             preInterpolationSpace: TD2D1_COLOR_SPACE; postInterpolationSpace: TD2D1_COLOR_SPACE; bufferPrecision: TD2D1_BUFFER_PRECISION;
             extendMode: TD2D1_EXTEND_MODE; colorInterpolationMode: TD2D1_COLOR_INTERPOLATION_MODE;

--- a/Units/DX12.D2D1.pas
+++ b/Units/DX12.D2D1.pas
@@ -2060,7 +2060,7 @@ type
         ['{a2296057-ea42-4099-983b-539fb6505426}']
         function GetSize(): TD2D1_SIZE_F; stdcall;
         function GetPixelSize(): TD2D1_SIZE_U; stdcall;
-        function GetPixelFormat(): TD2D1_PIXEL_FORMAT; stdcall;
+        procedure GetPixelSize(out pixelSize: TD2D1_SIZE_U); stdcall;
         procedure GetDpi(out dpiX: single; out dpiY: single); stdcall;
         //        function CopyFromBitmap( destPoint: PD2D1_POINT_2U; bitmap: ID2D1Bitmap;  srcRect: PD2D1_RECT_U): HResult; stdcall;  // <- funkt
         function CopyFromBitmap(const destPoint: PD2D1_POINT_2U; bitmap: ID2D1Bitmap; const srcRect: PD2D1_RECT_U): HResult;


### PR DESCRIPTION
Here's one example of how the implementation is wrong.

My change works as it should.

The original declaration comes with "D2D DEBUG ERROR - An interface [0019F388] not allocated by this DLL was passed to it."

GetPixelSize is a stdcall function.
stdcall pushes the parameters to the stack and returns the result in EAX.
In your implementation a (semi) random value from the stack is used as the parameter, the D2D DEBUG ERROR is correct about it not being an interface allocated by this DLL.

Same goes for GetSize and GetPixelFormat in this ID2D1Bitmap interface.